### PR TITLE
Hotfix - Changed `main` to `master`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Generate project documentation
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   # Build the documentation


### PR DESCRIPTION
### Problem
Documentation workflow was not running because it was set to push on `main` branch instead of `master`

### Resolution
Renamed `main` to `master`