### PR TITLE
Move timelines positions on level load

### DIFF
--- a/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelManager.cs
+++ b/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Application;
 using CoinPackage.Debugging;
 using UnityEngine;
+using Settings;
 
 namespace LevelTimeChange.LevelsLoader {
     /// <summary>
@@ -27,6 +28,7 @@ namespace LevelTimeChange.LevelsLoader {
             _logger.Log($"New scene has awoken: {currentLevel.sceneName % Colorize.Cyan}");
             
             FindTeleportsOnScene();
+            PrepareLevelContent();
             DeactivateLevel();
         }
 
@@ -88,5 +90,41 @@ namespace LevelTimeChange.LevelsLoader {
                 }
             }
         }
+
+		private void PrepareLevelContent() {
+			var timelines = FindTimelineMaps();
+			if (timelines == null) {
+				_logger.LogError($"Failed to find timelines in level {currentLevel.sceneName}." +
+                                  "Please make sure there are Past, Present, Future game objects under Content game object.");
+			}
+			MoveTimelines(timelines, DeveloperSettings.Instance.tpcSettings.offsetFromPresentPlatform);
+		}
+
+		private TimelineMaps FindTimelineMaps() {
+			var past = levelContent.transform.Find("Past")?.gameObject;
+			var present = levelContent.transform.Find("Present")?.gameObject;
+			var future = levelContent.transform.Find("Future")?.gameObject;
+			if (past == null || present == null || future == null) {
+				return null;
+			}
+			return new TimelineMaps(past, present, future);
+		}
+
+		private void MoveTimelines(TimelineMaps timelines, Vector3 offset) {
+			timelines.past.transform.position = timelines.present.transform.position - offset;
+			timelines.future.transform.position = timelines.present.transform.position + offset;
+		}
     }
+
+	class TimelineMaps {
+		public GameObject past {get; set;}
+		public GameObject present {get; set;}
+		public GameObject future {get; set;}
+
+		public TimelineMaps(GameObject past, GameObject present, GameObject future) {
+			this.past = past;
+			this.present = present;
+			this.future = future;
+		}
+	}
 }

--- a/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelManager.cs
+++ b/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelManager.cs
@@ -28,7 +28,7 @@ namespace LevelTimeChange.LevelsLoader {
             _logger.Log($"New scene has awoken: {currentLevel.sceneName % Colorize.Cyan}");
             
             FindTeleportsOnScene();
-            PrepareLevelContent();
+            SetTimelinesPositions();
             DeactivateLevel();
         }
 
@@ -91,7 +91,7 @@ namespace LevelTimeChange.LevelsLoader {
             }
         }
 
-		private void PrepareLevelContent() {
+		private void SetTimelinesPositions() {
 			var timelines = FindTimelineMaps();
 			if (timelines == null) {
 				_logger.LogError($"Failed to find timelines in level {currentLevel.sceneName}." +
@@ -101,9 +101,9 @@ namespace LevelTimeChange.LevelsLoader {
 		}
 
 		private TimelineMaps FindTimelineMaps() {
-			var past = levelContent.transform.Find("Past")?.gameObject;
-			var present = levelContent.transform.Find("Present")?.gameObject;
-			var future = levelContent.transform.Find("Future")?.gameObject;
+			var past = levelContent.transform.Find("Past");
+			var present = levelContent.transform.Find("Present");
+			var future = levelContent.transform.Find("Future");
 			if (past == null || present == null || future == null) {
 				return null;
 			}
@@ -111,17 +111,17 @@ namespace LevelTimeChange.LevelsLoader {
 		}
 
 		private void MoveTimelines(TimelineMaps timelines, Vector3 offset) {
-			timelines.past.transform.position = timelines.present.transform.position - offset;
-			timelines.future.transform.position = timelines.present.transform.position + offset;
+			timelines.past.position = timelines.present.position - offset;
+			timelines.future.position = timelines.present.position + offset;
 		}
     }
 
 	class TimelineMaps {
-		public GameObject past {get; set;}
-		public GameObject present {get; set;}
-		public GameObject future {get; set;}
+		public Transform past {get; set;}
+		public Transform present {get; set;}
+		public Transform future {get; set;}
 
-		public TimelineMaps(GameObject past, GameObject present, GameObject future) {
+		public TimelineMaps(Transform past, Transform present, Transform future) {
 			this.past = past;
 			this.present = present;
 			this.future = future;

--- a/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelsManager.cs
+++ b/Assets/Scripts/LevelTimeChange/LevelsLoader/LevelsManager.cs
@@ -104,7 +104,7 @@ namespace LevelTimeChange.LevelsLoader {
 			}
 		}
 
-		private void UnLoadLevel(LevelInfoSO level) {
+		private void UnloadLevel(LevelInfoSO level) {
 			_logger.Log($"Scene is being unloaded: {level.sceneName % Colorize.Magenta}");
 			SceneManager.UnloadSceneAsync(level.sceneName);
 			LoadedLevels.Remove(level);
@@ -120,7 +120,7 @@ namespace LevelTimeChange.LevelsLoader {
 				}
 			}
 			foreach (var scene in scenesToRemove) {
-				UnLoadLevel(scene);
+				UnloadLevel(scene);
 			}
 		}
 	}	


### PR DESCRIPTION
Closes https://trello.com/c/uMd94Zgn/13-automatyczne-rozlokowanie-timelines-przy-%C5%82adowaniu-sceny

Changes transform positions of Past and Future game objects on each level load, so that they are moved by settings defined vector with respect to Present timeline.

Also renames function UnLoadLevel (bleh) to UnloadLevel.