### PR TITLE
Door outline

### DIFF
--- a/Assets/Materials/Highlight.mat
+++ b/Assets/Materials/Highlight.mat
@@ -119,6 +119,7 @@ Material:
     - _GlossyReflections: 0
     - _Metallic: 0
     - _OcclusionStrength: 1
+    - _OnOff: 0
     - _Parallax: 0.005
     - _QueueControl: 0
     - _QueueOffset: 0
@@ -139,5 +140,5 @@ Material:
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
-    - _color: {r: 1, g: 1, b: 1, a: 1}
+    - _color: {r: 0, g: 4, b: 0.09411765, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scripts/Interactions/HighlightInteraction.cs
+++ b/Assets/Scripts/Interactions/HighlightInteraction.cs
@@ -23,7 +23,7 @@ namespace Interactions {
             _material.SetTexture("_texture", _sprite.sprite.texture);
             _material.SetFloat("_OnOff",0f);
             _material.SetFloat("_scale",0.01f);
-			_material.SetColor("_color",Color.green);
+            _material.SetColor("_color", Color.red);
 			_fadeIn = TurnHighlight(0f, 1f);
 			_fadeOut = TurnHighlight(1f, 0f);
         }

--- a/Assets/Shaders/Highlight.shadergraph
+++ b/Assets/Shaders/Highlight.shadergraph
@@ -146,6 +146,9 @@
         },
         {
             "m_Id": "2843e52994464cb4bfa685f4e470759b"
+        },
+        {
+            "m_Id": "e17a44a1fbfb4cec959a5c836edc5253"
         }
     ],
     "m_GroupDatas": [],
@@ -658,13 +661,13 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "e3463d1333594e2791825efb3ac67122"
+                    "m_Id": "e17a44a1fbfb4cec959a5c836edc5253"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 2
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "48b6fa1656b74c3da33a9c6d1cac201d"
+                    "m_Id": "0fc4ed6b21504174b72d6033709710b4"
                 },
                 "m_SlotId": 0
             }
@@ -672,13 +675,27 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "e3463d1333594e2791825efb3ac67122"
+                    "m_Id": "e17a44a1fbfb4cec959a5c836edc5253"
                 },
-                "m_SlotId": 7
+                "m_SlotId": 2
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0fc4ed6b21504174b72d6033709710b4"
+                    "m_Id": "bb17e3d470f5410b9f77f0326d1bacb5"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e3463d1333594e2791825efb3ac67122"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "48b6fa1656b74c3da33a9c6d1cac201d"
                 },
                 "m_SlotId": 0
             }
@@ -720,7 +737,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "bb17e3d470f5410b9f77f0326d1bacb5"
+                    "m_Id": "e17a44a1fbfb4cec959a5c836edc5253"
                 },
                 "m_SlotId": 1
             }
@@ -2769,6 +2786,54 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "7c495e288ff84a90b389454bca930323",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "7db20e558087499180e8e66f6c284e55",
     "m_Id": 0,
@@ -3747,13 +3812,13 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "r": 1.0,
-        "g": 1.0,
-        "b": 1.0,
+        "r": 4.0,
+        "g": 4.0,
+        "b": 4.0,
         "a": 0.0
     },
     "isMainColor": false,
-    "m_ColorMode": 0
+    "m_ColorMode": 1
 }
 
 {
@@ -4466,6 +4531,54 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "d3d70022a5db4bc3896111ce5dd6b09e",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
     "m_ObjectId": "d404212760944c05b19e7a7eaea5c425",
     "m_Id": 0,
@@ -4712,6 +4825,48 @@
         "m_Guid": ""
     },
     "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "e17a44a1fbfb4cec959a5c836edc5253",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -534.0001220703125,
+            "y": -89.00001525878906,
+            "width": 126.00006103515625,
+            "height": 117.99998474121094
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "fb09781332c046ac8cb9d307504b330b"
+        },
+        {
+            "m_Id": "d3d70022a5db4bc3896111ce5dd6b09e"
+        },
+        {
+            "m_Id": "7c495e288ff84a90b389454bca930323"
+        }
+    ],
+    "synonyms": [
+        "multiplication",
+        "times",
+        "x"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -5316,6 +5471,54 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "fb09781332c046ac8cb9d307504b330b",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.8999999761581421,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
     }
 }
 


### PR DESCRIPTION
Grafika drzwi zajmuje cały "obszar renderowania", więc jak shader dodaje do niego outline to nie widać, ponieważ się nie mieści.
Nie wiem jak można rozwiązać ten problem, więc zamiast tego zrobiłem, że obiekt interakcji zmienia trochę kolor.
Najlepiej zobaczyć jak to wygląda i usunąć pull request, jeśli brzydkie